### PR TITLE
feat: Add Vim Script highlights

### DIFF
--- a/lua/Aquavium/highlights.lua
+++ b/lua/Aquavium/highlights.lua
@@ -34,6 +34,11 @@ function M.apply(c, opts)
         DiagnosticVirtualTextWarn = { fg = c.yellow },
         DiagnosticVirtualTextInfo = { fg = c.cyan },
 
+        vimCommand = { fg = c.yellow },
+        vimBang = { fg = c.lightblue },
+        vimOper = { fg = c.purple },
+        vimUsrCmd = { fg = c.cyan },
+
         -- treesitter.nvim --
         ['@operator'] = { fg = c.sky },
 


### PR DESCRIPTION
<!-- 日本語/英語どちらでも構いません。 -->
<!-- Please use either English or Japanese. -->

## 概要 - Summary
- Vimスクリプト関連のハイライトグループを定義しました。

## 背景/変更理由 - Motivation
- `q` -> `:` などで表示される内容に色を適用するためです。

## 関連Issue - Related Issue
<!-- 例: Fixes #123 -->
<!-- e.g. Fixes #123 -->

## 変更点 - Changes
- `vimCommand`, `vimBang`, `vimOper`, `vimUsrCmd`を定義しました。

## テスト方法 - How to test (optional)
1.

## スクリーンショット - Screenshots (optional)

## チェックリスト - Checklist
- [x] セルフレビュー済み - Self-review completed
- [x] 必要なドキュメントのアップデート - Documentation updated if needed
- [x] 破壊的変更なし - No breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Vimエディタのシンタックスハイライト機能を拡張しました。コマンド、バング、演算子、ユーザーコマンドに対応する新しいハイライトグループが追加され、Vimコードの表示表現が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->