### PR TITLE
fix: Remove MatchParen fg definition

### DIFF
--- a/lua/Aquavium/highlights.lua
+++ b/lua/Aquavium/highlights.lua
@@ -16,7 +16,8 @@ function M.apply(c, opts)
         LineNr = { fg = c.gray },
         Function = { fg = c.cyan },
         EndOfBuffer = { fg = c.blue },
-        MatchParen = { fg = c.cyan, bold = opts.bold },
+
+        MatchParen = { bold = opts.bold },
 
         NormalFloat = { fg = c.fg },
 


### PR DESCRIPTION
<!-- 日本語/英語どちらでも構いません。 -->
<!-- Please use either English or Japanese. -->

## 概要 - Summary
- MatchParenのfgの定義を削除しました。

## 背景/変更理由 - Motivation
- すべてのTreesitterペアをMatchParenでハイライトする際に、違和感が生じるため。

## 関連Issue - Related Issue
<!-- 例: Fixes #123 -->
<!-- e.g. Fixes #123 -->

## 変更点 - Changes
- MatchParenのfgの定義を解除し、Boldのみが適用されるようになりました。

## テスト方法 - How to test (optional)
1.

## スクリーンショット - Screenshots (optional)

## チェックリスト - Checklist
- [x] セルフレビュー済み - Self-review completed
- [x] 必要なドキュメントのアップデート - Documentation updated if needed
- [x] 破壊的変更なし - No breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * マッチング括弧のハイライト表示のスタイルを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->