### PR TITLE
style: Change EOL code to LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,2 +1,2 @@
-line_endings = "Windows"
+line_endings = "Unix"
 indent_type = "Spaces"


### PR DESCRIPTION
<!-- 日本語/英語どちらでも構いません。 -->
<!-- Please use either English or Japanese. -->

## 概要 - Summary
- 改行コードをLFに変更しました。

## 背景/変更理由 - Motivation
- Styluaの誤作動の防止
- NeovimのPluginでは、一般的にLFコードが使用されているため、それに統一するため。

## 関連Issue - Related Issue
<!-- 例: Fixes #123 -->
<!-- e.g. Fixes #123 -->

## 変更点 - Changes
- editorconfigや、gitattributes、stylua上で改行コードをlfに指定

## テスト方法 - How to test (optional)
1.

## スクリーンショット - Screenshots (optional)

## チェックリスト - Checklist
- [x] セルフレビュー済み - Self-review completed
- [x] 必要なドキュメントのアップデート - Documentation updated if needed
- [x] 破壊的変更なし - No breaking changes
