### PR TITLE
feat: add neo-tree.nvim plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - [lazy.nvim](https://github.com/folke/lazy.nvim)
 - [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)
 - [Markview.nvim](https://github.com/OXY2DEV/markview.nvim)
+- [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim)
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 - [nvim-notify](https://github.com/rcarriga/nvim-notify)
 - [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context)

--- a/lua/Aquavium/integrations/init.lua
+++ b/lua/Aquavium/integrations/init.lua
@@ -6,6 +6,7 @@ local modules = {
     "dashboard",
     "lazy-nvim",
     "markview",
+    "neo-tree",
     "nvim-cmp",
     "nvim-notify",
     "telescope-nvim",

--- a/lua/Aquavium/integrations/neo-tree.lua
+++ b/lua/Aquavium/integrations/neo-tree.lua
@@ -19,4 +19,3 @@ function M.apply(c, opts)
 end
 
 return M
-

--- a/lua/Aquavium/integrations/neo-tree.lua
+++ b/lua/Aquavium/integrations/neo-tree.lua
@@ -1,0 +1,22 @@
+local utils = require("Aquavium.utils")
+local M = {}
+
+function M.apply(c, opts)
+    local hl = {
+        NeoTreeRootName = { fg = c.cyan, bg = c.bg1, bold = opts.bold },
+        NeoTreeGitAdded = { fg = c.cyan, bg = c.bg1, bold = opts.bold },
+        NeoTreeGitConflict = { fg = c.rose, bg = c.bg1, bold = opts.bold },
+        NeoTreeGitModified = { fg = c.yellow, bg = c.bg1, bold = opts.bold },
+        NeoTreeGitUntracked = { fg = c.rose, bg = c.bg1, bold = opts.bold },
+        NeoTreeTabInactive = { fg = c.gray, bg = c.bg1 },
+        NeoTreeTabSeparatorActive = { fg = c.bg2, bg = c.bg1 },
+        NeoTreeTabSeparatorInactive = { fg = c.bg2, bg = c.bg1 },
+    }
+
+    hl = utils.merge_highlights(hl, opts.custom_highlights, c, opts)
+
+    utils.apply_hl(hl)
+end
+
+return M
+

--- a/lua/Aquavium/integrations/neo-tree.lua
+++ b/lua/Aquavium/integrations/neo-tree.lua
@@ -3,11 +3,16 @@ local M = {}
 
 function M.apply(c, opts)
     local hl = {
+        -- Basic
         NeoTreeRootName = { fg = c.cyan, bg = c.bg1, bold = opts.bold },
+
+        -- Git
         NeoTreeGitAdded = { fg = c.cyan, bg = c.bg1, bold = opts.bold },
         NeoTreeGitConflict = { fg = c.rose, bg = c.bg1, bold = opts.bold },
         NeoTreeGitModified = { fg = c.yellow, bg = c.bg1, bold = opts.bold },
         NeoTreeGitUntracked = { fg = c.rose, bg = c.bg1, bold = opts.bold },
+
+        -- Tabs
         NeoTreeTabInactive = { fg = c.gray, bg = c.bg1 },
         NeoTreeTabSeparatorActive = { fg = c.bg2, bg = c.bg1 },
         NeoTreeTabSeparatorInactive = { fg = c.bg2, bg = c.bg1 },


### PR DESCRIPTION
## 概要 - Summary
- neo-tree.nvim のサポートを追加しました。

## 背景/変更理由 - Motivation
- 一部不自然な色要素があったため。

## 関連Issue - Related Issue
N/A

## 変更点 - Changes
- neo-tree.nvimのカラースキームを追加しました。
  - 一部はyaziを参考に実装しました。
- 上記に伴いドキュメントにneo-tree.nvimを追加しました。

## テスト方法 - How to test (optional)
1.

## スクリーンショット - Screenshots (optional)

## チェックリスト - Checklist
- [x] セルフレビュー済み - Self-review completed
- [x] 必要なドキュメントのアップデート - Documentation updated if needed
- [x] 破壊的変更なし - No breaking changes
- [x] (Markdown) GitHub上でのプレビュー済み - Previewed on GitHub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Neo-tree.nvim が正式サポートされ、ファイルツリーのハイライト、Git状態表示、タブ表示などに Aquavium カラースキームが自動適用されます。
* **ドキュメント**
  * サポートプラグイン一覧に Neo-tree.nvim を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->